### PR TITLE
Add offline Lolalytics scraping and modeling toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,51 @@
 # DataScience
-Data Science Tools 
+
+Utilities for scraping and modeling League of Legends champion synergy data, inspired by the Lolalytics statistics shown in the screenshot.
+
+## Project structure
+
+- `lolalytics/scraping.py` – parse the `window.__NUXT__` payload from a Lolalytics synergy page into tabular records.
+- `lolalytics/modeling.py` – create numerical features and train a lightweight gradient-descent regression model without external dependencies.
+- `lolalytics/data/sample_synergy.html` – a fixture mirroring the Lolalytics synergy table for Ahri. Use it for offline experiments when the real website is not reachable.
+- `tests/` – unit tests covering the scraping logic, CSV export and the regression workflow.
+
+## Usage
+
+1. **Scrape data**
+
+   ```bash
+   python -m lolalytics.scraping  # writes `ahri_synergy.csv` to the current directory using the sample HTML
+   ```
+
+   To scrape live data when network access is available:
+
+   ```python
+   from lolalytics.scraping import scrape_champion_synergy
+
+   records = scrape_champion_synergy("ahri", lane="middle", queue=420, region="world")
+   ```
+
+2. **Train the model**
+
+   ```bash
+   python -m lolalytics.modeling
+   ```
+
+   or programmatically:
+
+   ```python
+   from lolalytics import load_html_from_file, scrape_champion_synergy, train_synergy_model
+   from pathlib import Path
+
+   sample_html = Path("lolalytics/data/sample_synergy.html")
+   records = scrape_champion_synergy("ahri", html=load_html_from_file(sample_html))
+   model, metrics = train_synergy_model(records)
+   ```
+
+## Tests
+
+Run the unit test suite with:
+
+```bash
+python -m unittest discover -s tests
+```

--- a/lolalytics/__init__.py
+++ b/lolalytics/__init__.py
@@ -1,0 +1,31 @@
+"""Utilities for scraping and modeling League of Legends synergy data."""
+
+from .scraping import (
+    build_synergy_url,
+    extract_nuxt_payload,
+    load_html_from_file,
+    parse_synergy_records,
+    save_records_to_csv,
+    scrape_champion_synergy,
+)
+from .modeling import (
+    build_feature_matrix,
+    compute_metrics,
+    hash_feature,
+    LinearRegressionGD,
+    train_synergy_model,
+)
+
+__all__ = [
+    "build_synergy_url",
+    "extract_nuxt_payload",
+    "load_html_from_file",
+    "parse_synergy_records",
+    "save_records_to_csv",
+    "scrape_champion_synergy",
+    "build_feature_matrix",
+    "compute_metrics",
+    "hash_feature",
+    "LinearRegressionGD",
+    "train_synergy_model",
+]

--- a/lolalytics/data/sample_synergy.html
+++ b/lolalytics/data/sample_synergy.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Sample Lolalytics Synergy Data</title>
+</head>
+<body>
+  <div id="__nuxt">
+    <script type="text/javascript">
+      window.__NUXT__ = {
+        "data": [
+          {
+            "champion": {
+              "name": "Ahri",
+              "lane": "middle",
+              "synergy": {
+                "good": [
+                  {
+                    "ally": "Galio",
+                    "allyRole": "middle",
+                    "winRate": 54.82,
+                    "delta": 2.61,
+                    "deltaNormalized": 1.96,
+                    "pickRate": 5.24,
+                    "games": 15240
+                  },
+                  {
+                    "ally": "Jarvan IV",
+                    "allyRole": "jungle",
+                    "winRate": 54.10,
+                    "delta": 1.89,
+                    "deltaNormalized": 1.52,
+                    "pickRate": 3.92,
+                    "games": 12550
+                  },
+                  {
+                    "ally": "Rakan",
+                    "allyRole": "support",
+                    "winRate": 53.95,
+                    "delta": 1.45,
+                    "deltaNormalized": 1.18,
+                    "pickRate": 2.81,
+                    "games": 9832
+                  },
+                  {
+                    "ally": "Sejuani",
+                    "allyRole": "jungle",
+                    "winRate": 53.68,
+                    "delta": 1.21,
+                    "deltaNormalized": 0.97,
+                    "pickRate": 3.46,
+                    "games": 11400
+                  }
+                ],
+                "common": [
+                  {
+                    "ally": "Lux",
+                    "allyRole": "support",
+                    "winRate": 51.05,
+                    "delta": 0.75,
+                    "deltaNormalized": 0.57,
+                    "pickRate": 4.90,
+                    "games": 14005
+                  },
+                  {
+                    "ally": "Ezreal",
+                    "allyRole": "bottom",
+                    "winRate": 50.63,
+                    "delta": 0.32,
+                    "deltaNormalized": 0.25,
+                    "pickRate": 3.45,
+                    "games": 10395
+                  },
+                  {
+                    "ally": "Lee Sin",
+                    "allyRole": "jungle",
+                    "winRate": 49.82,
+                    "delta": -0.25,
+                    "deltaNormalized": -0.18,
+                    "pickRate": 4.13,
+                    "games": 11005
+                  },
+                  {
+                    "ally": "Thresh",
+                    "allyRole": "support",
+                    "winRate": 50.90,
+                    "delta": 0.62,
+                    "deltaNormalized": 0.46,
+                    "pickRate": 2.97,
+                    "games": 8903
+                  }
+                ],
+                "weak": [
+                  {
+                    "ally": "Yasuo",
+                    "allyRole": "middle",
+                    "winRate": 47.22,
+                    "delta": -2.90,
+                    "deltaNormalized": -2.14,
+                    "pickRate": 3.20,
+                    "games": 10002
+                  },
+                  {
+                    "ally": "Zed",
+                    "allyRole": "middle",
+                    "winRate": 46.75,
+                    "delta": -3.10,
+                    "deltaNormalized": -2.30,
+                    "pickRate": 2.47,
+                    "games": 8033
+                  },
+                  {
+                    "ally": "Pyke",
+                    "allyRole": "support",
+                    "winRate": 48.34,
+                    "delta": -1.85,
+                    "deltaNormalized": -1.35,
+                    "pickRate": 2.75,
+                    "games": 9201
+                  },
+                  {
+                    "ally": "Rengar",
+                    "allyRole": "jungle",
+                    "winRate": 45.60,
+                    "delta": -3.82,
+                    "deltaNormalized": -2.83,
+                    "pickRate": 1.95,
+                    "games": 6505
+                  }
+                ]
+              }
+            }
+          }
+        ]
+      };
+    </script>
+  </div>
+</body>
+</html>

--- a/lolalytics/modeling.py
+++ b/lolalytics/modeling.py
@@ -1,0 +1,145 @@
+"""Lightweight machine learning helpers for synergy prediction."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Dict, List, Sequence, Tuple
+
+SYNERGY_STRENGTH = {
+    "legendary": 2.0,
+    "strong": 1.5,
+    "good": 1.0,
+    "common": 0.0,
+    "weak": -1.0,
+    "poor": -1.5,
+}
+
+
+def hash_feature(value: str | None) -> float:
+    """Map a string feature to a deterministic value in ``[-0.5, 0.5]``."""
+
+    if not value:
+        return 0.0
+    digest = hashlib.sha256(value.encode("utf-8")).digest()
+    integer = int.from_bytes(digest[:8], "big")
+    return integer / 2**64 - 0.5
+
+
+def _synergy_strength_value(label: str | None) -> float:
+    if not label:
+        return 0.0
+    return SYNERGY_STRENGTH.get(label.lower(), 0.0)
+
+
+def build_feature_matrix(
+    records: Sequence[Dict[str, object]]
+) -> Tuple[List[List[float]], List[float]]:
+    """Convert parsed synergy records into a design matrix and targets."""
+
+    features: List[List[float]] = []
+    targets: List[float] = []
+
+    for record in records:
+        row = [
+            1.0,  # bias
+            float(record.get("delta", 0.0)),
+            float(record.get("delta_normalized", 0.0)),
+            float(record.get("pick_rate", 0.0)),
+            float(record.get("games", 0.0)) / 10000.0,
+            _synergy_strength_value(record.get("synergy_type")),
+            hash_feature(record.get("ally")),
+            hash_feature(record.get("ally_role")),
+        ]
+        features.append(row)
+        targets.append(float(record.get("win_rate", 0.0)))
+
+    return features, targets
+
+
+@dataclass
+class LinearRegressionGD:
+    """A minimal batch gradient-descent linear regressor."""
+
+    learning_rate: float = 0.01
+    epochs: int = 5000
+
+    def __post_init__(self) -> None:
+        self.weights: List[float] | None = None
+
+    def fit(self, features: Sequence[Sequence[float]], targets: Sequence[float]) -> "LinearRegressionGD":
+        if not features:
+            raise ValueError("No features supplied to fit the model")
+        n_samples = len(features)
+        n_features = len(features[0])
+        weights = [0.0] * n_features
+
+        for epoch in range(self.epochs):
+            gradients = [0.0] * n_features
+            for row, target in zip(features, targets):
+                prediction = self._predict_row(weights, row)
+                error = prediction - target
+                for index, value in enumerate(row):
+                    gradients[index] += error * value
+            for index in range(n_features):
+                weights[index] -= (self.learning_rate / n_samples) * gradients[index]
+        self.weights = weights
+        return self
+
+    @staticmethod
+    def _predict_row(weights: Sequence[float], row: Sequence[float]) -> float:
+        return sum(weight * value for weight, value in zip(weights, row))
+
+    def predict(self, features: Sequence[Sequence[float]]) -> List[float]:
+        if self.weights is None:
+            raise ValueError("The model has not been fitted yet")
+        return [self._predict_row(self.weights, row) for row in features]
+
+    def predict_single(self, row: Sequence[float]) -> float:
+        if self.weights is None:
+            raise ValueError("The model has not been fitted yet")
+        return self._predict_row(self.weights, row)
+
+
+def compute_metrics(predictions: Sequence[float], targets: Sequence[float]) -> Dict[str, float]:
+    """Calculate regression metrics (MSE, MAE, R^2)."""
+
+    total = len(targets)
+    if total == 0:
+        raise ValueError("Cannot compute metrics without targets")
+
+    mse = sum((pred - tgt) ** 2 for pred, tgt in zip(predictions, targets)) / total
+    mae = sum(abs(pred - tgt) for pred, tgt in zip(predictions, targets)) / total
+
+    mean_target = sum(targets) / total
+    ss_total = sum((tgt - mean_target) ** 2 for tgt in targets)
+    ss_res = sum((tgt - pred) ** 2 for pred, tgt in zip(predictions, targets))
+    r2 = 1 - ss_res / ss_total if ss_total else 0.0
+
+    return {"mse": mse, "mae": mae, "r2": r2}
+
+
+def train_synergy_model(
+    records: Sequence[Dict[str, object]],
+    learning_rate: float = 0.01,
+    epochs: int = 4000,
+) -> Tuple[LinearRegressionGD, Dict[str, float]]:
+    """Train a regression model on synergy records and return diagnostics."""
+
+    features, targets = build_feature_matrix(records)
+    model = LinearRegressionGD(learning_rate=learning_rate, epochs=epochs)
+    model.fit(features, targets)
+    predictions = model.predict(features)
+    metrics = compute_metrics(predictions, targets)
+    return model, metrics
+
+
+if __name__ == "__main__":  # pragma: no cover - manual smoke test
+    from pathlib import Path
+    from .scraping import load_html_from_file, scrape_champion_synergy
+
+    sample_html = Path(__file__).resolve().parent / "data" / "sample_synergy.html"
+    data = scrape_champion_synergy("ahri", html=load_html_from_file(sample_html))
+    model, metrics = train_synergy_model(data)
+    print("Trained model weights:", model.weights)
+    print("Metrics:", metrics)

--- a/lolalytics/scraping.py
+++ b/lolalytics/scraping.py
@@ -1,0 +1,234 @@
+"""Helpers for scraping champion synergy data from lolalytics.com."""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+from urllib import request, parse
+
+DEFAULT_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/120.0.0.0 Safari/537.36"
+    )
+}
+
+_NUXT_RE = re.compile(r"window\.__NUXT__\s*=\s*({.*?})\s*;\s*</script>", re.DOTALL)
+
+
+def build_synergy_url(
+    champion_slug: str,
+    lane: Optional[str] = "middle",
+    queue: Optional[int] = 420,
+    region: Optional[str] = "world",
+    patch: Optional[str] = None,
+) -> str:
+    """Construct the lolalytics synergy URL for a given champion.
+
+    Args:
+        champion_slug: URL slug for the champion (e.g. ``"ahri"``).
+        lane: Optional lane filter to include in the query string.
+        queue: Queue identifier (420 is solo queue). ``None`` omits the parameter.
+        region: Region string accepted by lolalytics (``"world"`` by default).
+        patch: Patch identifier such as ``"13.22"``. When ``None`` the site default
+            is used.
+
+    Returns:
+        A formatted URL string.
+    """
+
+    base = f"https://lolalytics.com/lol/{champion_slug}/synergy/"
+    params: Dict[str, Any] = {}
+    if lane:
+        params["lane"] = lane
+    if queue is not None:
+        params["queue"] = queue
+    if region:
+        params["region"] = region
+    if patch:
+        params["patch"] = patch
+
+    if params:
+        return base + "?" + parse.urlencode(params)
+    return base
+
+
+def fetch_url(url: str, timeout: float = 10.0) -> str:
+    """Fetch HTML content from a URL using :mod:`urllib`.
+
+    The helper sets a desktop browser user-agent because lolalytics rejects
+    requests with the default python identifier.
+    """
+
+    req = request.Request(url, headers=DEFAULT_HEADERS)
+    with request.urlopen(req, timeout=timeout) as response:  # type: ignore[arg-type]
+        content = response.read()
+    return content.decode("utf-8", errors="replace")
+
+
+def load_html_from_file(path: str | Path) -> str:
+    """Load HTML data from a local file."""
+
+    file_path = Path(path)
+    return file_path.read_text(encoding="utf-8")
+
+
+def extract_nuxt_payload(html: str) -> Dict[str, Any]:
+    """Extract the JSON payload embedded in the ``window.__NUXT__`` script.
+
+    Args:
+        html: The HTML document containing the ``window.__NUXT__`` assignment.
+
+    Raises:
+        ValueError: If the script tag cannot be located or the payload is not valid
+            JSON.
+    """
+
+    match = _NUXT_RE.search(html)
+    if not match:
+        raise ValueError("Unable to locate window.__NUXT__ payload in the document")
+    json_blob = match.group(1)
+    try:
+        return json.loads(json_blob)
+    except json.JSONDecodeError as exc:  # pragma: no cover - exercised via tests
+        raise ValueError("Invalid JSON payload in window.__NUXT__ script") from exc
+
+
+def _to_float(value: Any, default: float = 0.0) -> float:
+    try:
+        if value is None:
+            raise TypeError
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_int(value: Any, default: int = 0) -> int:
+    try:
+        if value is None:
+            raise TypeError
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def parse_synergy_records(
+    payload: Dict[str, Any],
+    include_categories: Optional[Iterable[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Convert a ``window.__NUXT__`` payload into tabular synergy records.
+
+    Args:
+        payload: Parsed JSON structure from :func:`extract_nuxt_payload`.
+        include_categories: Optional iterable restricting which synergy buckets are
+            included (e.g. ``{"good", "common"}``). ``None`` keeps every bucket.
+
+    Returns:
+        A list of dictionaries ready for CSV export or model training.
+    """
+
+    allowed = set(include_categories) if include_categories is not None else None
+    results: List[Dict[str, Any]] = []
+
+    data_sections = payload.get("data", [])
+    if not isinstance(data_sections, list):
+        return results
+
+    for section in data_sections:
+        if not isinstance(section, dict):
+            continue
+
+        champion_info: Dict[str, Any] = {}
+        if "champion" in section and isinstance(section["champion"], dict):
+            champion_info = section["champion"]
+        else:
+            champion_info = section
+
+        synergy_data = champion_info.get("synergy")
+        if not isinstance(synergy_data, dict):
+            continue
+
+        champion_name = champion_info.get("name") or section.get("name") or ""
+        lane = champion_info.get("lane") or section.get("lane") or ""
+
+        for synergy_type, entries in synergy_data.items():
+            if allowed is not None and synergy_type not in allowed:
+                continue
+            if not isinstance(entries, list):
+                continue
+            for entry in entries:
+                if not isinstance(entry, dict):
+                    continue
+                record = {
+                    "champion": champion_name,
+                    "lane": lane,
+                    "synergy_type": synergy_type,
+                    "ally": entry.get("ally") or entry.get("name") or "",
+                    "ally_role": entry.get("allyRole") or entry.get("role") or "",
+                    "win_rate": _to_float(entry.get("winRate")),
+                    "delta": _to_float(entry.get("delta")),
+                    "delta_normalized": _to_float(
+                        entry.get("deltaNormalized") or entry.get("normalizedDelta")
+                    ),
+                    "pick_rate": _to_float(entry.get("pickRate")),
+                    "games": _to_int(entry.get("games")),
+                }
+                results.append(record)
+
+    return results
+
+
+def save_records_to_csv(records: Iterable[Dict[str, Any]], path: str | Path) -> None:
+    """Persist parsed synergy records to a CSV file."""
+
+    fieldnames = [
+        "champion",
+        "lane",
+        "synergy_type",
+        "ally",
+        "ally_role",
+        "win_rate",
+        "delta",
+        "delta_normalized",
+        "pick_rate",
+        "games",
+    ]
+
+    file_path = Path(path)
+    with file_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in records:
+            writer.writerow(row)
+
+
+def scrape_champion_synergy(
+    champion_slug: str,
+    lane: Optional[str] = "middle",
+    queue: Optional[int] = 420,
+    region: Optional[str] = "world",
+    patch: Optional[str] = None,
+    html: Optional[str] = None,
+    fetch_html: Optional[Any] = None,
+    include_categories: Optional[Iterable[str]] = None,
+) -> List[Dict[str, Any]]:
+    """High level helper combining URL construction, fetching and parsing."""
+
+    if html is None:
+        url = build_synergy_url(champion_slug, lane=lane, queue=queue, region=region, patch=patch)
+        fetcher = fetch_html or fetch_url
+        html = fetcher(url)
+    payload = extract_nuxt_payload(html)
+    return parse_synergy_records(payload, include_categories=include_categories)
+
+
+if __name__ == "__main__":  # pragma: no cover - manual usage helper
+    sample_path = Path(__file__).resolve().parent / "data" / "sample_synergy.html"
+    records = scrape_champion_synergy("ahri", html=load_html_from_file(sample_path))
+    output_path = Path.cwd() / "ahri_synergy.csv"
+    save_records_to_csv(records, output_path)
+    print(f"Wrote {len(records)} records to {output_path}")

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -1,0 +1,44 @@
+import unittest
+from pathlib import Path
+
+from lolalytics import (
+    LinearRegressionGD,
+    build_feature_matrix,
+    compute_metrics,
+    load_html_from_file,
+    scrape_champion_synergy,
+    train_synergy_model,
+)
+
+
+class ModelingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        sample_path = Path(__file__).resolve().parents[1] / "lolalytics" / "data" / "sample_synergy.html"
+        cls.records = scrape_champion_synergy("ahri", html=load_html_from_file(sample_path))
+
+    def test_feature_matrix_has_expected_shape(self) -> None:
+        features, targets = build_feature_matrix(self.records)
+        self.assertEqual(len(features), len(targets))
+        self.assertGreater(len(features), 0)
+        self.assertEqual(len(features[0]), 8)
+
+    def test_linear_regression_training_reduces_error(self) -> None:
+        features, targets = build_feature_matrix(self.records)
+        model = LinearRegressionGD(learning_rate=0.01, epochs=6000)
+        model.fit(features, targets)
+        predictions = model.predict(features)
+        metrics = compute_metrics(predictions, targets)
+        self.assertLess(metrics["mse"], 5.0)
+        self.assertGreater(metrics["r2"], 0.65)
+
+    def test_train_synergy_model_helper_returns_metrics(self) -> None:
+        model, metrics = train_synergy_model(self.records, learning_rate=0.01, epochs=6000)
+        self.assertIsNotNone(model.weights)
+        self.assertIn("mse", metrics)
+        self.assertIn("mae", metrics)
+        self.assertIn("r2", metrics)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/tests/test_scraping.py
+++ b/tests/test_scraping.py
@@ -1,0 +1,57 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from lolalytics import (
+    build_synergy_url,
+    extract_nuxt_payload,
+    load_html_from_file,
+    parse_synergy_records,
+    save_records_to_csv,
+    scrape_champion_synergy,
+)
+
+
+class ScrapingTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.sample_path = Path(__file__).resolve().parents[1] / "lolalytics" / "data" / "sample_synergy.html"
+        cls.sample_html = load_html_from_file(cls.sample_path)
+
+    def test_extract_nuxt_payload(self) -> None:
+        payload = extract_nuxt_payload(self.sample_html)
+        self.assertIn("data", payload)
+
+    def test_parse_synergy_records(self) -> None:
+        payload = extract_nuxt_payload(self.sample_html)
+        records = parse_synergy_records(payload)
+        self.assertEqual(len(records), 12)
+        good_records = [row for row in records if row["synergy_type"] == "good"]
+        self.assertEqual(len(good_records), 4)
+        galio = next(row for row in records if row["ally"] == "Galio")
+        self.assertAlmostEqual(galio["win_rate"], 54.82, places=2)
+
+    def test_build_synergy_url(self) -> None:
+        url = build_synergy_url("ahri", lane="middle", queue=420, region="world", patch="13.22")
+        self.assertEqual(
+            url,
+            "https://lolalytics.com/lol/ahri/synergy/?lane=middle&queue=420&region=world&patch=13.22",
+        )
+
+    def test_scrape_champion_synergy_uses_provided_html(self) -> None:
+        records = scrape_champion_synergy("ahri", html=self.sample_html)
+        self.assertEqual(len(records), 12)
+
+    def test_save_records_to_csv(self) -> None:
+        payload = extract_nuxt_payload(self.sample_html)
+        records = parse_synergy_records(payload)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            output_path = Path(tmp_dir) / "synergy.csv"
+            save_records_to_csv(records, output_path)
+            csv_contents = output_path.read_text(encoding="utf-8")
+        self.assertIn("ally", csv_contents.splitlines()[0])
+        self.assertIn("Galio", csv_contents)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()


### PR DESCRIPTION
## Summary
- add scraping helpers to parse Lolalytics synergy pages into structured synergy records and CSV output
- implement a dependency-free gradient descent regression model plus utilities to build numeric features
- include an offline sample dataset, documentation updates, and unit tests for the scraping and modeling workflow

## Testing
- python -m unittest discover -s tests

------
https://chatgpt.com/codex/tasks/task_e_68ca72e112108330b74c998009ac7c21